### PR TITLE
[#23] 도메인 릴레이션 설정

### DIFF
--- a/src/main/java/com/didacto/domain/Enrollment.java
+++ b/src/main/java/com/didacto/domain/Enrollment.java
@@ -2,28 +2,57 @@ package com.didacto.domain;
 
 import com.didacto.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
+@AllArgsConstructor
 @NoArgsConstructor
 @Entity
+@Builder
 public class Enrollment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "enrollment_id")
     private Long id;
 
-    @Column(nullable = false)
-    private Long lectureId;
-
-    @Column(nullable = false)
-    private Long memberId;
-
     @Enumerated(EnumType.STRING)
     private EnrollmentStatus status = EnrollmentStatus.WAITING;
 
-    private Long modified_by;
+
+    /**
+     * 연관관꼐 매핑
+     */
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "modified_by", nullable = false)
+    private Member modified_by;
+
+
+    public void updateStatus(EnrollmentStatus status){
+        this.status = status;
+    }
+
+    public void updateModifiedMember(Member modifiedMember){
+        this.modified_by = modifiedMember;
+    }
+
+
 }

--- a/src/main/java/com/didacto/domain/Lecture.java
+++ b/src/main/java/com/didacto/domain/Lecture.java
@@ -9,6 +9,9 @@ import lombok.Setter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
@@ -23,9 +26,6 @@ public class Lecture extends BaseEntity {
     @Setter
     private String title;
 
-    @Column(nullable = false)
-    private Long ownerId;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private LectureState state;
@@ -37,22 +37,37 @@ public class Lecture extends BaseEntity {
     @Column(nullable = false)
     private Boolean deleted;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private Member owner;
+
+    @OneToMany(mappedBy = "lecture")
+    private List<Enrollment> enrollments;
+
+    @OneToMany(mappedBy = "lecture")
+    private List<LectureMember> lectureMembers;
+
     @Builder
     public Lecture(
             Long id,
             String title,
-            Long ownerId,
             LectureState state,
             OffsetDateTime startTime,
             OffsetDateTime endTime,
-            Boolean deleted
+            Boolean deleted,
+            Member owner,
+            List<Enrollment> enrollments,
+            List<LectureMember> lectureMembers
     ) {
         this.id = id;
         this.title = title;
-        this.ownerId = ownerId;
         this.state = state;
         this.startTime = startTime;
         this.endTime = endTime;
         this.deleted = deleted;
+        this.owner = owner;
+        this.enrollments = enrollments;
+        this.lectureMembers = lectureMembers;
     }
+
 }

--- a/src/main/java/com/didacto/domain/LectureMember.java
+++ b/src/main/java/com/didacto/domain/LectureMember.java
@@ -2,28 +2,45 @@ package com.didacto.domain;
 
 import com.didacto.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @Entity
+@Builder
 public class LectureMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "lecture_member_id")
     private Long id;
 
-    @Column(nullable = false)
-    private Long lectureId;
-
-    @Column(nullable = false)
-    private Long memberId;
-
-    @Column(nullable = false)
     private Boolean deleted = false;
 
-    private Long modifiedBy;
+
+    /**
+     * 연관관계 매핑
+     */
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
+    // private Long lectureId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+    // private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "modified_by", nullable = false)
+    private Member modifiedBy;
+    // private Long modifiedBy;
 }

--- a/src/main/java/com/didacto/domain/Member.java
+++ b/src/main/java/com/didacto/domain/Member.java
@@ -6,6 +6,9 @@ import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 
 @Getter
@@ -36,6 +39,20 @@ public class Member {
     @CreatedDate
     @Column(nullable = false)
     private OffsetDateTime created_date;
+
+    /**
+     * 연관관계 세팅
+     */
+
+    @OneToMany(mappedBy = "owner")
+    private List<Lecture> own_lectures;
+
+    @OneToMany(mappedBy = "member")
+    private List<Enrollment> enrollments;
+
+    @OneToMany(mappedBy = "member")
+    private List<LectureMember> lectureMembers;
+
 
 
     /**

--- a/src/main/java/com/didacto/dto/lecture/LectureResponse.java
+++ b/src/main/java/com/didacto/dto/lecture/LectureResponse.java
@@ -21,7 +21,8 @@ public class LectureResponse {
     public LectureResponse(Lecture lecture) {
         this.id = lecture.getId();
         this.title = lecture.getTitle();
-        this.ownerId = lecture.getOwnerId();
+        // TODO#23 : 도메인 변경에 따라 수정 필요
+//        this.ownerId = lecture.getOwnerId();
         this.start_time = lecture.getStartTime();
         this.end_time = lecture.getEndTime();
         this.deleted = lecture.getDeleted();

--- a/src/main/java/com/didacto/service/lecture/LectureCommandService.java
+++ b/src/main/java/com/didacto/service/lecture/LectureCommandService.java
@@ -18,7 +18,8 @@ public class LectureCommandService {
     public Lecture create(LectureCreationRequest request) {
         Lecture lecture = Lecture.builder()
                 .title(request.getTitle())
-                .ownerId(request.getOwnerId())
+                // TODO#23 : 도메인 변경에 따라 수정 필요
+//                .ownerId(request.getOwnerId())
                 .deleted(false)
                 .state(LectureState.WAITING)
                 .build();


### PR DESCRIPTION
## 🔍 이슈 번호
+ #23 

## 🛠️ 작업 
+ 연관관계 매핑을 위해서 도메인들의 필드 타입 수정
+ 지금 연관관계에 있는 컬럼들이 Long으로 선언되어 있어 매핑이 불가능하므로 불가피하게 타입을 모두 변경합니다.
+ 기존 로직에서 해당 변경사항으로 인해 수정이 필요한 부분은 TODO#23 으로 주석처리 해둠
+ 해당 연관관계 필드 변경이 되지 않으면 기존 작업들 및 앞으로의 작업들이 큰 난황이 될 것이므로 급하게 PR 요청.
+ 해당 PR은 최대한 빠르게 병합하고 Develop 브랜치 땡겨서 작업 진행

## 💡특이사항
+ 리뷰받고 싶은 내용을 작성
+ 논의 필요 사항 작성