### PR TITLE
feature/10-lecture

### DIFF
--- a/src/main/java/com/didacto/controller/v1/lecture/LectureCommandController.java
+++ b/src/main/java/com/didacto/controller/v1/lecture/LectureCommandController.java
@@ -2,6 +2,7 @@ package com.didacto.controller.v1.lecture;
 
 import com.didacto.common.response.CommonResponse;
 import com.didacto.config.security.AuthConstant;
+import com.didacto.config.security.SecurityUtil;
 import com.didacto.domain.Lecture;
 import com.didacto.dto.lecture.LectureCreationRequest;
 import com.didacto.dto.lecture.LectureModificationRequest;
@@ -27,7 +28,7 @@ public class LectureCommandController {
     public CommonResponse<Long> create(
             @RequestBody LectureCreationRequest request
     ){
-        Lecture lecture = lectureCommandService.create(request);
+        Lecture lecture = lectureCommandService.create(request, SecurityUtil.getCurrentMemberId());
         return new CommonResponse(
                 true, HttpStatus.OK, null, lecture.getId()
         );

--- a/src/main/java/com/didacto/dto/lecture/LectureCreationRequest.java
+++ b/src/main/java/com/didacto/dto/lecture/LectureCreationRequest.java
@@ -10,12 +10,9 @@ import lombok.NoArgsConstructor;
 public class LectureCreationRequest {
     @Schema(example = "강의 제목")
     private String title;
-    @Schema(example = "1")
-    private Long ownerId;
 
     @Builder
-    public LectureCreationRequest(String title, Long ownerId) {
+    public LectureCreationRequest(String title) {
         this.title = title;
-        this.ownerId = ownerId;
     }
 }

--- a/src/main/java/com/didacto/service/lecture/LectureCommandService.java
+++ b/src/main/java/com/didacto/service/lecture/LectureCommandService.java
@@ -21,8 +21,8 @@ public class LectureCommandService {
     private final MemberQueryService memberQueryService;
 
     @Transactional
-    public Lecture create(LectureCreationRequest request) {
-        Member member = memberQueryService.query(request.getOwnerId());
+    public Lecture create(LectureCreationRequest request, Long createdBy) {
+        Member member = memberQueryService.query(createdBy);
 
         Lecture lecture = Lecture.builder()
                 .title(request.getTitle())

--- a/src/test/java/com/didacto/service/lecture/LectureServiceTest.java
+++ b/src/test/java/com/didacto/service/lecture/LectureServiceTest.java
@@ -55,11 +55,10 @@ public class LectureServiceTest {
         // given
         LectureCreationRequest request = LectureCreationRequest.builder()
                 .title("강의 제목")
-                .ownerId(tutorId)
                 .build();
 
         // when
-        Lecture lecture = lectureCommandService.create(request);
+        Lecture lecture = lectureCommandService.create(request, tutorId);
 
         // then
         assertThat(lecture).isNotNull();


### PR DESCRIPTION
## 🛠️ 작업 
+ ownerId를 Request Body로 대신 요청자의 보안 컨텍스트의 PK를 사용하도록 (일관성 유지)