### PR TITLE
[#37] Enrollment 예외상황 추가 (Delete 케이스) 

### DIFF
--- a/src/main/java/com/didacto/common/ErrorDefineCode.java
+++ b/src/main/java/com/didacto/common/ErrorDefineCode.java
@@ -26,8 +26,10 @@ public enum ErrorDefineCode {
     ALREADY_JOIN("ENROLL_3", "이미 강의에 등록된 상태입니다."),
     ALREADY_ENROLL("ENROLL_4", "등록 요청에 대한 처리가 이미 완료되었습니다. 혹은 해당 등록 처리에 대한 사용자의 권한이 없습니다."),
     NOT_FOUND_ENROLL("ENROLL_5", "해당 초대 정보를 찾을 수 없습니다."),
+    CONFIRM_FAIL_USER_DELETED("ENROLL_6", "등록 요청을 한 사용자가 탈퇴하였습니다. 해당 요청은 취소 처리됩니다."),
     LECTURE_MEMBER_NOT_FOUND("LMB_01", "강의 참여자를 찾을 수 없습니다."),
     LECTURE_MEMBER_ALREADY_EXISTENCE("LMB_02", "이미 강의에 등록된 사용자입니다."),
+    DELETED_LECTURE("LECTURE_01", "삭제된 강의입니다."),
     ;
 
     private final String code;


### PR DESCRIPTION
## 🔍 이슈 번호
+ #37 

## 🛠️ 작업 
+ Delete된 연관 데이터에 대한 처리 로직을 추가한다.
+ 강의 참여 요청 시 삭제된 Lecture에는 신청할 수 없다
+ 교수자의 요청 승인 및 거절 시 탈퇴한 유저의 요청에 대해서는 CANCELED 상태로 변경하고 관련 내용을 Exception Message로 전달한다.

## 💡특이사항
+ Transactional 처리된 메서드에서 Exception을 throw하기 전 특정 시점에 트랜잭션 커밋을 하는 좋은 방법 있으면 공유부탁드립니다.
