### PR TITLE
[#45] 강의 삭제 버그 픽스

### DIFF
--- a/src/main/java/com/didacto/domain/Lecture.java
+++ b/src/main/java/com/didacto/domain/Lecture.java
@@ -7,11 +7,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @EntityListeners(AuditingEntityListener.class)
 @Getter
@@ -69,10 +68,12 @@ public class Lecture extends BaseEntity {
         this.lectureMembers = lectureMembers;
     }
 
+    @Transactional
     public void modify(String title) {
         this.title = title;
     }
 
+    @Transactional
     public void delete() {
         this.deleted = true;
     }

--- a/src/main/java/com/didacto/dto/lecture/LectureModificationRequest.java
+++ b/src/main/java/com/didacto/dto/lecture/LectureModificationRequest.java
@@ -1,20 +1,15 @@
 package com.didacto.dto.lecture;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class LectureModificationRequest {
     @Schema(example = "1")
     private Long lectureId;
 
     @Schema(example = "수정된 강의 제목")
     private String title;
-
-    @Builder
-    public LectureModificationRequest(Long lectureId, String title) {
-        this.lectureId = lectureId;
-        this.title = title;
-    }
 }

--- a/src/main/java/com/didacto/service/lecture/LectureCommandService.java
+++ b/src/main/java/com/didacto/service/lecture/LectureCommandService.java
@@ -33,6 +33,7 @@ public class LectureCommandService {
         return lectureRepository.save(lecture);
     }
 
+    @Transactional
     public Lecture modify(LectureModificationRequest request) {
         Lecture lecture = lectureRepository.findById(request.getLectureId()).orElseThrow(()
                 -> new NoSuchElementFoundException404(ErrorDefineCode.LECTURE_NOT_FOUND)
@@ -43,6 +44,7 @@ public class LectureCommandService {
         return lectureRepository.save(lecture);
     }
 
+    @Transactional
     public Lecture delete(Long lectureId) {
         Lecture lecture = lectureRepository.findById(lectureId).orElseThrow(()
                 -> new NoSuchElementFoundException404(ErrorDefineCode.LECTURE_NOT_FOUND)


### PR DESCRIPTION
## 🔍 이슈 번호
+ 45 강의 삭제 버그

## 🛠️ 작업 
+ 누락된 Transactional 어노테이션 추가
+ 수정 api 쪽도 동일한 이슈 발생하여 수정했음

## 💡특이사항
+ 없음