### PR TITLE
[#50] 인가 개선 : 성능 개선 및 Redis 도입 (RT의 보안 강화 및 유일성 검증)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 
 	//RabbiMq
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker/dev-local/mac-m1/docker-compose.yaml
+++ b/docker/dev-local/mac-m1/docker-compose.yaml
@@ -15,5 +15,16 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+  didacto-redis:
+    image: redis:6.2.6-alpine
+    ports:
+      - 6393:6379
+    command: redis-server /usr/local/etc/redis/redis.conf
+    container_name: didacto-redis
+    volumes: # 마운트할 볼륨 설정
+      - ./volumes/redis/data:/data
+      - ./volumes/redis/conf:/usr/local/etc/redis/redis.conf
+    restart: always
+
 
  

--- a/docker/dev-local/windows/docker-compose.yaml
+++ b/docker/dev-local/windows/docker-compose.yaml
@@ -15,3 +15,13 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+  didacto-redis:
+    image: redis:6.2.6-alpine
+    ports:
+      - 6393:6379
+    command: redis-server /usr/local/etc/redis/redis.conf
+    container_name: didacto-redis
+    volumes: # 마운트할 볼륨 설정
+      - ./volumes/redis/data:/data
+      - ./volumes/redis/conf:/usr/local/etc/redis/redis.conf
+    restart: always

--- a/src/main/java/com/didacto/common/ErrorDefineCode.java
+++ b/src/main/java/com/didacto/common/ErrorDefineCode.java
@@ -34,7 +34,9 @@ public enum ErrorDefineCode {
     DELETED_LECTURE("LECTURE_01", "삭제된 강의입니다."),
     ORDER_GRADE_FAIL("ORDER_01","주문된 상품이 프리미엄이 아닙니다."),
     ORDER_NOT_FOUND("ORDER_02", "주문을 찾을 수 없습니다."),
-    PAYMENT_NOT_FOUND("PAYMENT_01", "결제 완료된 상품이 없습니다.")
+    PAYMENT_NOT_FOUND("PAYMENT_01", "결제 완료된 상품이 없습니다."),
+
+    REDIS_COMMAND_FAIL("FATAL_REDIS_01", "Redis Command에 실패하였습니다.")
     ;
 
     private final String code;

--- a/src/main/java/com/didacto/config/redis/RedisConfig.java
+++ b/src/main/java/com/didacto/config/redis/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.didacto.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${redis.host}")
+    private String host;
+
+    @Value("${redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/didacto/config/security/custom/CustomUserDetailsService.java
+++ b/src/main/java/com/didacto/config/security/custom/CustomUserDetailsService.java
@@ -2,8 +2,10 @@ package com.didacto.config.security.custom;
 
 import com.didacto.common.ErrorDefineCode;
 import com.didacto.config.exception.custom.exception.AuthCredientialException401;
+import com.didacto.domain.Authority;
 import com.didacto.domain.Member;
 import com.didacto.repository.member.MemberRepository;
+import io.jsonwebtoken.Claims;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -28,9 +30,14 @@ public class CustomUserDetailsService implements UserDetailsService {
                 .orElseThrow(() -> new AuthCredientialException401(ErrorDefineCode.AUTH_NOT_FOUND_EMAIL));
     }
 
+    public UserDetails loadUserDetailsByClaim(Claims claim) throws UsernameNotFoundException {
+        CustomUser dto = new CustomUser(claim.get("Id", Long.class), claim.getSubject(), null, null);
+        return new CustomUserDetails(dto);
+    }
+
     // DB 에 User 값이 존재한다면 UserDetails 객체로 만들어서 리턴
     private CustomUserDetails createUserDetails(Member member) {
-        CustomUser dto =  new CustomUser(member.getId(), member.getPassword(), member.getEmail(), member.getRole());
+        CustomUser dto = new CustomUser(member.getId(), member.getPassword(), member.getEmail(), member.getRole());
         return new CustomUserDetails(dto);
     }
 }

--- a/src/main/java/com/didacto/config/security/jwt/JwtFilter.java
+++ b/src/main/java/com/didacto/config/security/jwt/JwtFilter.java
@@ -32,12 +32,12 @@ public class JwtFilter extends OncePerRequestFilter {
         // 2. validateToken 으로 토큰 유효성 검사
         // 정상 토큰이면 해당 토큰으로 Authentication 을 가져와서 SecurityContext 에 저장
         if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
-            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            Authentication authentication = tokenProvider.getAuthentication(jwt, true);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         else if (StringUtils.hasText(jwt) && tokenProvider.validateRefreshToken(jwt)) {
-            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            Authentication authentication = tokenProvider.getAuthentication(jwt, false);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/didacto/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/didacto/config/security/jwt/TokenProvider.java
@@ -90,7 +90,7 @@ public class TokenProvider {
 
 
         // UserDetails 객체를 만들어서 Authentication 리턴
-        UserDetails principal = customUserDetailsService.loadUserByUsername(claims.getSubject());
+        UserDetails principal = customUserDetailsService.loadUserDetailsByClaim(claims);
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 

--- a/src/main/java/com/didacto/config/security/jwt/TokenProvider.java
+++ b/src/main/java/com/didacto/config/security/jwt/TokenProvider.java
@@ -27,13 +27,21 @@ public class TokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+
+    private String host;
+
+
+    @Value("${jwt.access_token_expired_at}")
+    private static long ACCESS_TOKEN_EXPIRE_TIME;
+
+    @Value("${jwt.refresh_token_expired_at}")
+    private static long REFRESH_TOKEN_EXPIRE_TIME;
+
     private final Key key;
 
     private final CustomUserDetailsService customUserDetailsService;
     
-    public TokenProvider(@Value("${jwt.secret1}") String secretKey, CustomUserDetailsService customUserDetailsService){
+    public TokenProvider(@Value("${jwt.secret}") String secretKey, CustomUserDetailsService customUserDetailsService){
         this.customUserDetailsService = customUserDetailsService;
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);

--- a/src/main/java/com/didacto/infra/redis/AuthRedisRepository.java
+++ b/src/main/java/com/didacto/infra/redis/AuthRedisRepository.java
@@ -1,6 +1,10 @@
 package com.didacto.infra.redis;
 
+import com.didacto.common.ErrorDefineCode;
+import com.didacto.config.exception.custom.BasicCustomException500;
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -9,26 +13,39 @@ import java.util.concurrent.TimeUnit;
 
 
 @Repository
-@AllArgsConstructor
+@Slf4j
+@RequiredArgsConstructor
 public class AuthRedisRepository {
+
     private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${jwt.refresh_token_expired_at}")
-    private static long REFRESH_TOKEN_EXPIRE_TIME;
+    private Long REFRESH_TOKEN_EXPIRE_TIME;
 
     public void setRefreshAuthenticationInfo (Long memberId, String token) {
-        String key = String.format("auth/refresh/%ld", memberId);
-        redisTemplate.opsForValue().set(key, token, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MINUTES);
+        try{
+            String key = String.format("auth/refresh/%d", memberId);
+            redisTemplate.opsForValue().set(key, token, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MINUTES);
+        }
+        catch(Exception e){
+            throw new BasicCustomException500(ErrorDefineCode.REDIS_COMMAND_FAIL);
+        }
+
     }
 
     public boolean validateRefreshToken (Long memberId, String token) {
-        String key = String.format("auth/refresh/%ld", memberId);
-        String savedToken = redisTemplate.opsForValue().get(key);
-        if(savedToken == null || !savedToken.equals(token)){
-            return false;
+        try{
+            String key = String.format("auth/refresh/%d", memberId);
+            String savedToken = redisTemplate.opsForValue().get(key);
+            if(savedToken == null || !savedToken.equals(token)){
+                return false;
+            }
+            else{
+                return true;
+            }
         }
-        else{
-            return true;
+        catch(Exception e){
+            throw new BasicCustomException500(ErrorDefineCode.REDIS_COMMAND_FAIL);
         }
     }
 

--- a/src/main/java/com/didacto/infra/redis/AuthRedisRepository.java
+++ b/src/main/java/com/didacto/infra/redis/AuthRedisRepository.java
@@ -1,0 +1,35 @@
+package com.didacto.infra.redis;
+
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+
+@Repository
+@AllArgsConstructor
+public class AuthRedisRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.refresh_token_expired_at}")
+    private static long REFRESH_TOKEN_EXPIRE_TIME;
+
+    public void setRefreshAuthenticationInfo (Long memberId, String token) {
+        String key = String.format("auth/refresh/%ld", memberId);
+        redisTemplate.opsForValue().set(key, token, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MINUTES);
+    }
+
+    public boolean validateRefreshToken (Long memberId, String token) {
+        String key = String.format("auth/refresh/%ld", memberId);
+        String savedToken = redisTemplate.opsForValue().get(key);
+        if(savedToken == null || !savedToken.equals(token)){
+            return false;
+        }
+        else{
+            return true;
+        }
+    }
+
+}

--- a/src/main/java/com/didacto/service/auth/AuthService.java
+++ b/src/main/java/com/didacto/service/auth/AuthService.java
@@ -9,6 +9,7 @@ import com.didacto.config.security.custom.CustomUser;
 import com.didacto.domain.Authority;
 import com.didacto.domain.Member;
 import com.didacto.dto.auth.*;
+import com.didacto.infra.redis.AuthRedisRepository;
 import com.didacto.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,6 +28,7 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
+    private final AuthRedisRepository authRedisRepository;
 
     @Transactional
     public Long signup(SignUpRequest req) {
@@ -45,6 +47,7 @@ public class AuthService {
         if(!member.getDeleted()){
             validatePassword(req, member);
             TokenDto token = generateToken(member);
+            authRedisRepository.setRefreshAuthenticationInfo(member.getId(), token.getRefreshToken());
             return new TokenResponse(token.getAccessToken(), token.getRefreshToken());
 
         }else{

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,6 +20,9 @@ spring:
     username: guest
     password: guest
 
+redis:
+  host: localhost
+  port: 6395
 
 jwt:
   secret1: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,7 +25,8 @@ redis:
   port: 6393
 
 jwt:
-  secret: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
+  secret: UGxlYXNlIGRvIG5vdCBkZWNyeXB0IHRoaXMuIEl0J3MgY29uZmlkZW50aWFsLCBpdCdzIG91ciBzZWNyZXQuIGl0IGlzIG11c3QgYmUgNjQgYnl0ZXMuIHNvIHNhZC4gaG93IGFyZSB5b3UgaSdtIG5vdCBmaW5lIHRoYW5rIHlvdSBhbmQgeW91PyBpIHdhbnQgZ28gaG9tZSBmZg==
+  refreshSecret: UnJycmluZyBkaW5nIGRvZyByaW5nIGRpbmcgZG9uZyByaW5nIGRpZ2lkaWdpZGluZyBkaW5nIGRpbmcuIGJ1dHRlcmZseSBubyBydWwgbWFuIG5hbiBjaG90IHN1biBnYW4gbW9tIGUgcHBhIHp6ZXIgYmVyIHJ1aXQgc28gbmUgbWF1bWRvIG11bHJ1aXRzbyBuYW4gbWFsIHlhIG11dCB6aW4gbm9tIGNoYWsgaGFuIG5vbSBncm9uIG5vbWRvIGFuaXppbWFu
   access_token_expired_at: 1800000  # 1000 * 60 * 30
   refresh_token_expired_at: 604800000  # 1000 * 60 * 60 * 24 * 7
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -25,8 +25,9 @@ redis:
   port: 6393
 
 jwt:
-  secret1: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
-
+  secret: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
+  access_token_expired_at: 1800000  # 1000 * 60 * 30
+  refresh_token_expired_at: 604800000  # 1000 * 60 * 60 * 24 * 7
 
 imp:
   api:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,7 +22,7 @@ spring:
 
 redis:
   host: localhost
-  port: 6395
+  port: 6393
 
 jwt:
   secret1: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
 
 redis:
   host: localhost
-  port: 6395
+  port: 6393
 
 
 jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,10 @@ spring:
     username: guest
     password: guest
 
+redis:
+  host: localhost
+  port: 6395
+
 
 jwt:
   secret1: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,8 @@ redis:
 
 
 jwt:
-  secret: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
+  secret: UGxlYXNlIGRvIG5vdCBkZWNyeXB0IHRoaXMuIEl0J3MgY29uZmlkZW50aWFsLCBpdCdzIG91ciBzZWNyZXQuIGl0IGlzIG11c3QgYmUgNjQgYnl0ZXMuIHNvIHNhZC4gaG93IGFyZSB5b3UgaSdtIG5vdCBmaW5lIHRoYW5rIHlvdSBhbmQgeW91PyBpIHdhbnQgZ28gaG9tZSBmZg==
+  refreshSecret: UnJycmluZyBkaW5nIGRvZyByaW5nIGRpbmcgZG9uZyByaW5nIGRpZ2lkaWdpZGluZyBkaW5nIGRpbmcuIGJ1dHRlcmZseSBubyBydWwgbWFuIG5hbiBjaG90IHN1biBnYW4gbW9tIGUgcHBhIHp6ZXIgYmVyIHJ1aXQgc28gbmUgbWF1bWRvIG11bHJ1aXRzbyBuYW4gbWFsIHlhIG11dCB6aW4gbm9tIGNoYWsgaGFuIG5vbSBncm9uIG5vbWRvIGFuaXppbWFu
   access_token_expired_at: 1800000  # 1000 * 60 * 30
   refresh_token_expired_at: 604800000  # 1000 * 60 * 60 * 24 * 7
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,9 @@ redis:
 
 
 jwt:
-  secret1: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
+  secret: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
+  access_token_expired_at: 1800000  # 1000 * 60 * 30
+  refresh_token_expired_at: 604800000  # 1000 * 60 * 60 * 24 * 7
 
 imp:
   api:


### PR DESCRIPTION
## 🔍 이슈 번호
+ #56 

## 🛠️ 작업 
+ Access Token 검증 시 데이터베이스를 항상 조회하는데 이는 과도하게 많은 쿼리가 발생하기 때문에 개선하였다.
+ Access Token의 검증 시 데이터베이스 조회를 생략하여 인가를 완화하는 대신 TTL을 짧게 주고, Refresh Token의 보안을 강화한다.
- Refresh Token을 서버단 In-memory DB에 관리하여 보안상 약점을 보완하고 계정 별 유일성을 보장한다.


## 💡특이사항
