### PR TITLE
[#68] CI 및 통합 테스트 시 Embedded-Redis 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
 	//test
 	testRuntimeOnly 'com.h2database:h2'
-	testImplementation 'it.ozimov:embedded-redis:0.7.2'
+	testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/didacto/config/redis/RedisConfig.java
+++ b/src/main/java/com/didacto/config/redis/RedisConfig.java
@@ -6,11 +6,13 @@ import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
+@Profile("!test")
 public class RedisConfig {
     @Value("${redis.host}")
     private String host;

--- a/src/test/java/com/didacto/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/didacto/config/EmbeddedRedisConfig.java
@@ -1,0 +1,47 @@
+package com.didacto.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.junit.jupiter.api.DisplayName;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+@DisplayName("Embedded Redis 설정")
+@Profile("test")
+@Configuration
+public class EmbeddedRedisConfig {
+
+    private int port;
+    private RedisServer redisServer;
+
+    public EmbeddedRedisConfig(@Value("${spring.data.redis.port}") int port) throws IOException {
+        this.port = port;
+        this.redisServer = new RedisServer(port);
+    }
+
+    @PostConstruct
+    public void startRedis() throws IOException {
+        this.redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() throws IOException {
+        this.redisServer.stop();
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://localhost:" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/test/java/com/didacto/repository/enrollment/EnrollmentRepositorylTest.java
+++ b/src/test/java/com/didacto/repository/enrollment/EnrollmentRepositorylTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -23,10 +24,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-@Disabled
 @SpringBootTest
-@AutoConfigureTestDatabase
 @Transactional
+@ActiveProfiles("test")
 class EnrollmentRepositorylTest {
 
     @Autowired

--- a/src/test/java/com/didacto/service/enrollment/EnrollmentCommandServiceTest.java
+++ b/src/test/java/com/didacto/service/enrollment/EnrollmentCommandServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -29,10 +30,9 @@ import static org.assertj.core.groups.Tuple.tuple;
 import static org.junit.jupiter.api.Assertions.*;
 
 
-@Disabled
 @SpringBootTest
-@AutoConfigureTestDatabase
 @Transactional
+@ActiveProfiles("test")
 class EnrollmentCommandServiceTest {
 
     @Autowired

--- a/src/test/java/com/didacto/service/enrollment/EnrollmentQueryServiceTest.java
+++ b/src/test/java/com/didacto/service/enrollment/EnrollmentQueryServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -25,10 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
-@Disabled
 @SpringBootTest
-@AutoConfigureTestDatabase
 @Transactional
+@ActiveProfiles("test")
 class EnrollmentQueryServiceTest {
 
     @Autowired

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,17 +1,20 @@
 spring:
   datasource:
-    initialization-mode: always
     url: jdbc:h2:mem:testdb
     username: sa
     password:
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
     defer-datasource-initialization: true
+  data:
+    redis:
+      port: 6399
 
 logging.level:
   org.hibernate.SQL: debug
+


### PR DESCRIPTION
## 🔍 이슈 번호
+ #68 

## 🛠️ 작업 
- CI 및 통합 테스트 시 Embedded-Redis 환경 추가
  * 기존에 CI 시 로컬 빌드 과정에서 Redis 의존성에 의해 Bean으로 등록하지 못하여 실패하는 현상 발생
  * H2 데이터베이스처럼 테스트 환경에서 사용할 수 있는 별도 환경 구축 필요
+ Enrollment 코드는 @Disabled 해제한 이후 @AutoConfigureDatabase 대신 @ActiveProfiles("test") 적용. 마찬가지로 다른 @Disabled된 테스트 코드들 정상화 필요

## 💡체크리스트
- [x] 빌드 정상 성공 확인
- [ ] 전체 테스트 코드 실행 및 CI 성공 확인

## 💡특이사항
+ Gradle 의존성 추가되었음.
+ Embedded-Redis 특성 상 운영체제 이슈가 있다고 하였음. 해당 브랜치 체크아웃하여 각자 운영체제에서 전체 테스트 코드 실행하여 (활성화해 둔 것만) 전체 파란불 뜨는지 확인 후 코멘트 필요
  * 운영체제 이슈가 MAC M1(본인 운영체제)이 가장 심하여 서칭 결과 호환이 가장 잘 되는 Embedded-Redis를 의존성으로 추가해둔 상태 및 본인은 성공 확인
